### PR TITLE
pom.xml is missing log4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,5 +95,10 @@
       <artifactId>commons-codec</artifactId>
       <version>1.6</version>
     </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.15</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Added a missing log4j dependency to pom.xml. Without it the downloaded elfinder-servlet project refused to compile.
